### PR TITLE
Fix errors with transparent gifs

### DIFF
--- a/CImage.php
+++ b/CImage.php
@@ -2224,7 +2224,7 @@ class CImage
             ? imagecolortransparent($this->image)
             : -1;
 
-        if ($index != -1) {
+	    if ($index >= 0 && $index < imagecolorstotal($this->image)) {
 
             imagealphablending($img, true);
             $transparent = imagecolorsforindex($this->image, $index);


### PR DESCRIPTION
Fixes error "imagecolorsforindex(): Color index XXX out of range" by checking with the pallet size of the image.